### PR TITLE
Fix full config image overlay not loading

### DIFF
--- a/src/components/ConfigCard/ConfigCard.tsx
+++ b/src/components/ConfigCard/ConfigCard.tsx
@@ -113,7 +113,7 @@ export function ConfigCard({ config }: ConfigCardProps) {
             onClick={closeOverlay}
           >
             <Image
-              src={`https://1klcjc8um5aq.flarial.xyz/api/configs/${config.id}/icon.png`}
+              src={`https://marketplace.flarial.xyz/api/configs/${config.id}/icon.png`}
               alt="Full Config Image"
               layout="fill"
               objectFit="contain"


### PR DESCRIPTION
Fixes this issue:
![image](https://github.com/user-attachments/assets/0d4fec23-efa3-4f07-97ed-e9275d9d8a91)
